### PR TITLE
feat: Update site metadata for improved SEO

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,8 +12,8 @@ import { StructuredData } from '@/components/structured-data'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'RubixKube - Site Reliability Intelligence is the future',
-  description: 'Detect, diagnose, and heal production issues before customers feel them. Autonomous remediation with approvals for Kubernetes and cloud-native stacks.',
+  title: 'Site Reliability Intelligence (SRI) | RubixKube',
+  description: 'Detect, diagnose, and heal production issues before customers feel them. AI-native reliability for Kubernetes. Book a demo.',
   keywords: [
     'site reliability intelligence',
     'SRI', 
@@ -57,9 +57,6 @@ export const metadata: Metadata = {
       'max-image-preview': 'large',
       'max-snippet': -1,
     },
-  },
-  verification: {
-    google: 'your-google-site-verification-code',
   },
 }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -66,15 +66,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ]
 
-  const blogIndex: MetadataRoute.Sitemap = [
-    {
-      url: `${baseUrl}/blog`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-  ]
-
   const blogEntries: MetadataRoute.Sitemap = posts.map((p) => ({
     url: `${baseUrl}/blog/${p.slug.current}`,
     lastModified: p.publishedAt ? new Date(p.publishedAt) : new Date(),
@@ -82,5 +73,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }))
 
-  return [...staticEntries, ...blogIndex, ...blogEntries]
+  return [...staticEntries, ...blogEntries]
 }


### PR DESCRIPTION
This pull request focuses on improving the site's metadata for SEO and cleaning up the sitemap logic. The most notable changes are updates to the homepage metadata, removal of unused verification fields, and simplification of the sitemap generation.

**SEO and Metadata Improvements:**

* Updated the homepage `title` and `description` in `metadata` to be more concise and focused on "Site Reliability Intelligence (SRI)" and RubixKube branding.
* Removed the `verification` field for Google site verification from the metadata, as it was either unused or placeholder content.

**Sitemap Simplification:**

* Removed the separate `/blog` index entry from the sitemap, so now only individual blog posts are included, streamlining the sitemap output.